### PR TITLE
Adicionado configurador de URL e Operações

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -14,7 +14,7 @@ class Tools extends RestCurl
 
     public function consultarNfseChave($chave)
     {
-        $operacao = 'nfse/' . $chave;
+        $operacao = str_replace("{chave}", $chave, $this->getOperation('consultar_nfse'));
         $retorno = $this->getData($operacao);
 
         if (isset($retorno['erro'])) {
@@ -30,7 +30,7 @@ class Tools extends RestCurl
 
     public function consultarDpsChave($chave)
     {
-        $operacao = 'dps/' . $chave;
+        $operacao = str_replace("{chave}", $chave, $this->getOperation('consultar_dps'));
         $retorno = $this->getData($operacao);
 
         return $retorno;
@@ -38,20 +38,24 @@ class Tools extends RestCurl
 
     public function consultarNfseEventos($chave, $tipoEvento = null, $nSequencial = null)
     {
-        $operacao = 'nfse/' . $chave . '/eventos';
-        if ($tipoEvento) {
-            $operacao .= '/' . $tipoEvento;
+        $operacao = str_replace("{chave}", $chave, $this->getOperation('consultar_eventos'));
+        if (!$tipoEvento) {
+            $operacao = str_replace("/{tipoEvento}/{nSequencial}", "", $operacao);
         }
-        if ($nSequencial) {
-            $operacao .= '/' . $nSequencial;
+        $operacao .= str_replace("{tipoEvento}", $tipoEvento, $operacao);
+        
+        if (!$nSequencial) {
+            $operacao = str_replace("/{nSequencial}", "", $operacao);
         }
+        $operacao .= str_replace("{nSequencial}", $nSequencial, $operacao);
+
         $retorno = $this->getData($operacao);
         return $retorno;
     }
 
     public function consultarDanfse($chave)
     {
-        $operacao = 'danfse/' . $chave;
+        $operacao = str_replace("{chave}", $chave, $this->getOperation('consultar_danfse'));
         $retorno = $this->getData($operacao, null, 2);
         if (isset($retorno['erro'])) {
             return $retorno;
@@ -73,10 +77,10 @@ class Tools extends RestCurl
      */
     public function consultarDanfseNfse($chave)
     {
-        $operacao = 'Certificado';
+        $operacao = $this->getOperation('consultar_danfse_nfse_certificado');
         $retorno = $this->getData($operacao, null, 3);
         if(isset($retorno) and isset($retorno['sucesso']) and $retorno['sucesso']==true){
-            $operacao = 'Notas/Download/DANFSe/'.$chave;
+            $operacao = str_replace("{chave}", $chave, $this->getOperation('consultar_danfse_nfse_download'));
             $retorno = $this->getData($operacao, null, 3);
         }
         if (isset($retorno['erro'])) {
@@ -98,7 +102,8 @@ class Tools extends RestCurl
         $dados = [
             'dpsXmlGZipB64' => $data
         ];
-        $retorno = $this->postData('nfse', json_encode($dados));
+        $operacao = $this->getOperation('emitir_nfse');
+        $retorno = $this->postData($operacao, json_encode($dados));
         return $retorno;
     }
 
@@ -114,7 +119,7 @@ class Tools extends RestCurl
         $dados = [
             'pedidoRegistroEventoXmlGZipB64' => $data
         ];
-        $operacao = 'nfse/' . $std->infPedReg->chNFSe . '/eventos';
+        $operacao = str_replace("{chave}", $std->infPedReg->chNFSe, $this->getOperation('cancelar_nfse'));
         $retorno = $this->postData($operacao, json_encode($dados));
         return $retorno;
     }

--- a/storage/prefeituras.json
+++ b/storage/prefeituras.json
@@ -1,0 +1,12 @@
+{
+    "americana-sp": {
+        "urls": {
+            "sefin_producao": "https://nfse.americana.sp.gov.br/api/adn/dps/recepcao",
+            "sefin_homologacao": "https://americanahomologacao.nfe.com.br/api/adn/dps/recepcao"
+        },
+        "operations":{
+            "emitir_nfse" : "",
+            "cancelar_nfse" : ""
+        }
+    }
+}


### PR DESCRIPTION
Algumas prefeituras, como americana-sp, que apesar de possuirem emissor proprio e não permitirem o envio direto para a nfs-e nacional, estão permitindo a transmissão do leiaute nacional para seus servidores.

Dessa forma, para facilitar a configuração das prefeituras que possuem esse tipo de espelhamento, efetuei algumas alterações para facilitar a configuração destas. Sendo assim, foi adicionado um arquivo de configuração das prefeituras para override de URL e Operacoes default do ambiente nacional, tornando fácil o processo de configuração das URL e Operacoes definidos pela prefeitura, que receberá a nfs-e com o leiaute nacional através de seus servidores.