### PR TITLE
fix: use null coalescing operator for undefined array keys in loadCon…

### DIFF
--- a/src/RestCurl.php
+++ b/src/RestCurl.php
@@ -67,9 +67,9 @@ class RestCurl extends RestBase
 
         $contextData = $json[$context] ?? [];
 
-        $this->URLS = $this->mergeDefaults(self::DEFAULT_URLS, $contextData['urls'] ?: []);
+        $this->URLS = $this->mergeDefaults(self::DEFAULT_URLS, $contextData['urls'] ?? []);
 
-        $this->OPERATIONS = $this->mergeDefaults(self::DEFAULT_OPERATIONS, $contextData['operations'] ?: []);
+        $this->OPERATIONS = $this->mergeDefaults(self::DEFAULT_OPERATIONS, $contextData['operations'] ?? []);
 
     }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                 
  Fix "Undefined array key" error when using a `prefeitura` value that doesn't exist in `prefeituras.json`.                                                                                                  
                                                                                                                                                                                                             
  ## Problem                                                                                                                                                                                                 
  The `loadConfigOverrides` method in `RestCurl.php` uses the Elvis operator (`?:`) to provide default values:                                                                                               
                                                                                                                                                                                                             
  ```php                                                                                                                                                                                                     
  $contextData = $json[$context] ?: [];                                                                                                                                                                      
  $this->URLS = $this->mergeDefaults(self::DEFAULT_URLS, $contextData['urls'] ?: []);                                                                                                                        
  $this->OPERATIONS = $this->mergeDefaults(self::DEFAULT_OPERATIONS, $contextData['operations'] ?: []);                                                                                                      
  ```
                                                                                                                                                                                                           
  The Elvis operator only works for falsy values, but throws "Undefined array key" when the key doesn't exist at all.                                                                                        
                                                                                                                                                                                                             
  Solution                                                                                                                                                                                                   
                                                                                                                                                                                                             
  Replace ?: with the null coalescing operator ??, which properly handles non-existent keys:                                                                                                                 
  ```php
  $contextData = $json[$context] ?? [];                                                                                                                                                                      
  $this->URLS = $this->mergeDefaults(self::DEFAULT_URLS, $contextData['urls'] ?? []);                                                                                                                        
  $this->OPERATIONS = $this->mergeDefaults(self::DEFAULT_OPERATIONS, $contextData['operations'] ?? []);                                                                                                      
  ```
  This allows users to use the default NFSe Nacional URLs without needing to add entries to prefeituras.json.