### PR TITLE
fix: corrige ordem dos parâmetros em mb_convert_encoding no método co…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "nesbot/carbon": "^3.8",
     "ext-curl": "*",
     "ext-zlib": "*",
-    "ext-openssl": "*"
+    "ext-openssl": "*",
+    "ext-mbstring": "*"
   },
   "config": {
     "optimize-autoloader": true

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -23,7 +23,7 @@ class Tools extends RestCurl
         if ($retorno) {
             $base_decode = base64_decode($retorno['nfseXmlGZipB64']);
             $gz_decode = gzdecode($base_decode);
-            return mb_convert_encoding($gz_decode, 'ISO-8859-1', 'UTF-8');
+            return mb_convert_encoding($gz_decode, 'UTF-8', 'ISO-8859-1');
         }
         return null;
     }
@@ -43,7 +43,7 @@ class Tools extends RestCurl
             $operacao = str_replace("/{tipoEvento}/{nSequencial}", "", $operacao);
         }
         $operacao .= str_replace("{tipoEvento}", $tipoEvento, $operacao);
-        
+
         if (!$nSequencial) {
             $operacao = str_replace("/{nSequencial}", "", $operacao);
         }


### PR DESCRIPTION
 - Corrige a ordem dos parâmetros na função mb_convert_encoding no método consultarNfseChave, que estava convertendo de UTF-8 para ISO-8859-1 quando deveria ser o contrário. Pra mim falha com erro de encoding sem essa correção.
  - Adiciona ext-mbstring como dependência no composer.json, já que a função mb_convert_encoding é utilizada no código.