### PR TITLE
Fix: corrigir montagem da URL de consulta de eventos NFSe

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -42,12 +42,12 @@ class Tools extends RestCurl
         if (!$tipoEvento) {
             $operacao = str_replace("/{tipoEvento}/{nSequencial}", "", $operacao);
         }
-        $operacao .= str_replace("{tipoEvento}", $tipoEvento, $operacao);
+        $operacao = str_replace("{tipoEvento}", $tipoEvento, $operacao);
 
         if (!$nSequencial) {
             $operacao = str_replace("/{nSequencial}", "", $operacao);
         }
-        $operacao .= str_replace("{nSequencial}", $nSequencial, $operacao);
+        $operacao = str_replace("{nSequencial}", $nSequencial, $operacao);
 
         $retorno = $this->getData($operacao);
         return $retorno;


### PR DESCRIPTION
### O que foi corrigido
Corrige a montagem da URL na consulta de eventos de NFSe (`consultarNfseEventos`), evitando a duplicação do caminho ao substituir os placeholders `{tipoEvento}` e `{nSequencial}`.

### Problema
A URL estava sendo construída de forma incorreta devido à concatenação (`.=`) da própria string após o `str_replace`, resultando em caminhos duplicados, por exemplo:

`nfse/{chave}/eventos/{tipoEvento}/{nSequencial}nfse/{chave}/eventos/101101/{nSequencial}...`

### Solução
Substituição direta dos placeholders (`=` em vez de `.=`), garantindo que a URL final seja construída corretamente para todos os cenários:
- somente chave
- chave + tipo de evento
- chave + tipo de evento + número sequencial

### Impacto
- Corrige chamadas inválidas à API
- Não altera a interface pública do método
- Não quebra compatibilidade com implementações existentes

-----------

### Resumindo

Estava com problema na montagem da URL na consulta de eventos.

**Estava montando a URL assim:** (ex.: **EVENTO CANCELAMENTO: 101101**)
```
nfse/553532612243163184000000000223331242131241241/eventos/{tipoEvento}/{nSequencial}nfse/553532612243163184000000000223331242131241241/eventos/101101/{nSequencial}nfse/553532612243163184000000000223331242131241241/eventos/{tipoEvento}/1nfse/553532612243163184000000000223331242131241241/eventos/101101/1"
```

**Deveria ser assim:**
```
"nfse/553532612243163184000000000223331242131241241/eventos/101101/1"
```
