### PR TITLE
feat: adiciona Santana de Parnaíba - SP e propõe refatoração para código IBGE

### DIFF
--- a/storage/prefeituras.json
+++ b/storage/prefeituras.json
@@ -1,5 +1,5 @@
 {
-    "americana-sp": {
+    "3501608": {
         "urls": {
             "sefin_producao": "https://nfse.americana.sp.gov.br/api/adn/dps/recepcao",
             "sefin_homologacao": "https://americanahomologacao.nfe.com.br/api/adn/dps/recepcao"
@@ -7,6 +7,19 @@
         "operations":{
             "emitir_nfse" : "",
             "cancelar_nfse" : ""
+        }
+    },
+    "3547304": {
+        "urls": {
+            "sefin_producao": "https://nfsesantanadeparnaiba.simplissweb.com.br",
+            "sefin_homologacao": "https://producaorestrita.simplissweb.com.br",
+            "adn_producao": "https://nfsesantanadeparnaiba.simplissweb.com.br",
+            "adn_homologacao": "https://producaorestrita.simplissweb.com.br"
+        },
+        "operations":{
+            "emitir_nfse" : "nfse",
+            "cancelar_nfse" : "nfse/{chave}/eventos",
+            "consultar_danfse": "nfse/{chave}"
         }
     }
 }


### PR DESCRIPTION
**Alterações Realizadas**
Adicionada a prefeitura de Santana de Parnaíba - SP ao arquivo schemes/prefeituras.json.

**Sugestão de Melhoria (RFC)**
Proponho uma alteração na estrutura das chaves de identificação no arquivo prefeituras.json: substituir o nome da prefeitura pelo seu respectivo código IBGE.

**Justificativa:**
Padronização: O código IBGE é um identificador único e imutável, ao contrário de nomes que podem sofrer variações de acentuação ou grafia.
Performance: Como o código IBGE já é uma informação obrigatória na emissão de NFSe, a utilização dele como chave elimina a necessidade de consultas extras (queries) apenas para buscar o nome exato da prefeitura, otimizando o fluxo de integração.
Facilidade de Acesso: É uma informação técnica de fácil obtenção e amplamente utilizada em ecossistemas de documentos fiscais.

**Checklist**
- Município adicionado seguindo o schema atual.
- Testado localmente.
- Aguardando feedback sobre a sugestão de refatoração para os códigos IBGE.
