### PR TITLE
Adiciona suporte aos municípios Contagem-MG e Regente Feijó-SP

### DIFF
--- a/src/RestCurl.php
+++ b/src/RestCurl.php
@@ -43,6 +43,7 @@ class RestCurl extends RestBase
     public string $responseBody;
     private string $requestHead;
     private string $cookies = '';
+    private int $eventoPronim = 0;
 
     protected $canonical = [true, false, null, null];
 
@@ -357,7 +358,7 @@ class RestCurl extends RestBase
     /**
      * Função para refatorar a requisição/resposta para o formato esperado pelo provedor Pronim
      * @param string|array $data requisição já comprimida e em base64 ou array de resposta
-     * @param int $evento tipo de evento 1 = envio de DPS, 2 = cancelamento de DPS, 99 = resposta da requisição
+     * @param int $evento tipo de evento 1 = envio de DPS, 2 = cancelamento de DPS, 999 = resposta da requisição
      * @return array|string requisição refatorada conforme o provedor
      * @author leandro-mafra
      */

--- a/src/RestCurl.php
+++ b/src/RestCurl.php
@@ -43,7 +43,7 @@ class RestCurl extends RestBase
     public string $responseBody;
     private string $requestHead;
     private string $cookies = '';
-    private int $eventoPronim = 0;
+    private int $eventogovCloud = 0;
 
     protected $canonical = [true, false, null, null];
 
@@ -316,7 +316,7 @@ class RestCurl extends RestBase
 
     /**
      * Função para refatorar a requisição para o formato correto esperado pelo provedor, ou a resposta da requisição para poder manter uma saída padrão, ou pelo menos o mais próximo para manter a compatibilidade
-     * Alguns municípios com provedor próprio (Pronim é um deles) tem a requisição/resposta num formato um pouco diferente do sistema nacional
+     * Alguns municípios com provedor próprio (govCloud é um deles) tem a requisição/resposta num formato um pouco diferente do sistema nacional
      * Esta função vai refatorar a requisição/resposta para ficar de acordo com o que o provedor espera
      * @param string|array $data requisição já comprimida e em base64 ou array de resposta
      * @param int $evento tipo de evento 1 = envio de DPS, 2 = cancelamento de DPS, 999 = resposta da requisição(até o momento é esperado que sejá usado apenas para envio de DPS e Eventos )
@@ -330,9 +330,9 @@ class RestCurl extends RestBase
         switch($this->config->prefeitura){
             case '3118601': // Contagem - MG
             case '3542404': // Regente Feijó - SP
-                // pronim
+                // govCloud
                 // tando o envio quanto o cancelamento tem o mesmo formato
-                $return = $this->pronimRefactor($data, $evento);
+                $return = $this->govCloudRefactor($data, $evento);
                 break;
             default:
                 // sistema nacional - qualquer outro município
@@ -356,13 +356,13 @@ class RestCurl extends RestBase
     }
 
     /**
-     * Função para refatorar a requisição/resposta para o formato esperado pelo provedor Pronim
+     * Função para refatorar a requisição/resposta para o formato esperado pelo provedor govCloud
      * @param string|array $data requisição já comprimida e em base64 ou array de resposta
      * @param int $evento tipo de evento 1 = envio de DPS, 2 = cancelamento de DPS, 999 = resposta da requisição
      * @return array|string requisição refatorada conforme o provedor
      * @author leandro-mafra
      */
-    private function pronimRefactor(string|array $data, int $evento): array|string
+    private function govCloudRefactor(string|array $data, int $evento): array|string
     {
         $return = [];
 
@@ -382,7 +382,7 @@ class RestCurl extends RestBase
                 unset($arrayTemp1['lote']);
                 $return = array_merge($arrayTemp1, $arrayTemp2);
 
-                if ($this->eventoPronim == 1) {
+                if ($this->eventogovCloud == 1) {
                     // no sistema nacioanl a nota emitida vem nessa posição 'nfseXmlGZipB64'
                     $return['nfseXmlGZipB64'] = $return['xmlGZipB64'] ?? null;
                     if (array_key_exists('xmlGZipB64', $return)) {
@@ -425,7 +425,7 @@ class RestCurl extends RestBase
                 'LoteXmlGZipB64' => [$data]
             ];
 
-            $this->eventoPronim = $evento;
+            $this->eventogovCloud = $evento;
         }
         return $return;
     }

--- a/src/RestCurl.php
+++ b/src/RestCurl.php
@@ -405,6 +405,10 @@ class RestCurl extends RestBase
                                     unset($return['erros'][$key]['codigo']); // remove a key com texto incorreto
                                     $return['erros'][$key]['Codigo'] = $itemR; // adiciona a key com o texto correto
                                 }
+                                if ($keyR === 'descricao') {
+                                    unset($return['erros'][$key]['descricao']); // remove a key com texto incorreto
+                                    $return['erros'][$key]['Descricao'] = $itemR; // adiciona a key com o texto correto
+                                }
                             }
                         }
                     } else {

--- a/src/RestCurl.php
+++ b/src/RestCurl.php
@@ -232,6 +232,8 @@ class RestCurl extends RestBase
             curl_close($oCurl);
             $this->responseHead = trim(substr($response, 0, $headsize));
             $this->responseBody = trim(substr($response, $headsize));
+            $this->responseBody = $this->refactorFormatProvider($this->responseBody, 999);
+
             return json_decode($this->responseBody, true);
         } catch (Exception $e) {
             throw SoapException::unableToLoadCurl($e->getMessage());
@@ -309,5 +311,121 @@ class RestCurl extends RestBase
         if (!empty($cookies)) {
             $this->cookies = implode('; ', $cookies);
         }
+    }
+
+    /**
+     * Função para refatorar a requisição para o formato correto esperado pelo provedor, ou a resposta da requisição para poder manter uma saída padrão, ou pelo menos o mais próximo para manter a compatibilidade
+     * Alguns municípios com provedor próprio (Pronim é um deles) tem a requisição/resposta num formato um pouco diferente do sistema nacional
+     * Esta função vai refatorar a requisição/resposta para ficar de acordo com o que o provedor espera
+     * @param string|array $data requisição já comprimida e em base64 ou array de resposta
+     * @param int $evento tipo de evento 1 = envio de DPS, 2 = cancelamento de DPS, 999 = resposta da requisição(até o momento é esperado que sejá usado apenas para envio de DPS e Eventos )
+     * @return array|string requisição refatorada conforme o provedor
+     * @author leandro-mafra
+     */
+    public function refactorFormatProvider(string|array $data, int $evento): array|string
+    {
+        $return = [];
+        // busca o município pelo código ibge passado na configuração da classe Tools
+        switch($this->config->prefeitura){
+            case '3118601': // Contagem - MG
+            case '3542404': // Regente Feijó - SP
+                // pronim
+                // tando o envio quanto o cancelamento tem o mesmo formato
+                $return = $this->pronimRefactor($data, $evento);
+                break;
+            default:
+                // sistema nacional - qualquer outro município
+                    if ($evento == 999) {
+                        // resposta
+                        $return = $data;
+                    } elseif ($evento == 1) {
+                        // envio DPS
+                        $return = [
+                            'dpsXmlGZipB64' => $data
+                        ];
+                    } else {
+                        // evento de cancelamento
+                        $return = [
+                            'pedidoRegistroEventoXmlGZipB64' => $data
+                        ];
+                    }
+                break;
+        }
+        return $return;
+    }
+
+    /**
+     * Função para refatorar a requisição/resposta para o formato esperado pelo provedor Pronim
+     * @param string|array $data requisição já comprimida e em base64 ou array de resposta
+     * @param int $evento tipo de evento 1 = envio de DPS, 2 = cancelamento de DPS, 99 = resposta da requisição
+     * @return array|string requisição refatorada conforme o provedor
+     * @author leandro-mafra
+     */
+    private function pronimRefactor(string|array $data, int $evento): array|string
+    {
+        $return = [];
+
+        if ($evento == 999) {
+            // resposta
+            //
+            // checa se a resposta já está no formato esperado
+            $jsonTemp = json_decode($data, true);
+            if (
+                json_last_error() === JSON_ERROR_NONE && // checa se é um json válido
+                array_key_exists('lote', $jsonTemp)
+            ) {
+                // formata para retirar o conteúdo do nível "lote" e passar para o nível superior, mantendo o que estiver fora do "lote"
+                // assim ficando mais próximo do formato padrão do sistema nacional
+                $arrayTemp1 = $jsonTemp;
+                $arrayTemp2 = $jsonTemp['lote'][0];
+                unset($arrayTemp1['lote']);
+                $return = array_merge($arrayTemp1, $arrayTemp2);
+
+                if ($this->eventoPronim == 1) {
+                    // no sistema nacioanl a nota emitida vem nessa posição 'nfseXmlGZipB64'
+                    $return['nfseXmlGZipB64'] = $return['xmlGZipB64'] ?? null;
+                    if (array_key_exists('xmlGZipB64', $return)) {
+                        unset($return['xmlGZipB64']);
+                    }
+                } else {
+                    // no sistema nacioanl o retorno dos eventos (pelo menos o de cancelamento que eu sei) emitida vem nessa posição 'eventoXmlGZipB64'
+                    $return['eventoXmlGZipB64'] = $return['xmlGZipB64'] ?? null;
+                    if (array_key_exists('xmlGZipB64', $return)) {
+                        unset($return['xmlGZipB64']);
+                    }
+                }
+
+                // se tiver erro corrige a forma que está escrito a key "codigo" para "Codigo"(para ficar igual ao sistema nacional)
+                if (isset($return['erros'])) {
+                    if (count($return['erros']) > 0) {
+                        foreach($return['erros'] as $key => $item) {
+                            foreach($item as $keyR => $itemR) {
+                                if ($keyR === 'codigo') {
+                                    unset($return['erros'][$key]['codigo']); // remove a key com texto incorreto
+                                    $return['erros'][$key]['Codigo'] = $itemR; // adiciona a key com o texto correto
+                                }
+                            }
+                        }
+                    } else {
+                        // caso a key "erros" exista e for vazia, será removida
+                        unset($return['erros']);
+                    }
+                }
+
+                $return = json_encode($return);
+            } else {
+                // fora do padrão esperado, nesse caso costuma ser um erro de conexão por exemplo
+                // então vai retornar apenas o que foi recebido
+                $return = $data;
+            }
+        } else {
+            // tando o envio quanto o cancelamento tem o mesmo formato
+            $return = [
+                'LoteXmlGZipB64' => [$data]
+            ];
+
+            $this->eventoPronim = $evento;
+        }
+        return $return;
     }
 }

--- a/src/RestCurl.php
+++ b/src/RestCurl.php
@@ -398,7 +398,7 @@ class RestCurl extends RestBase
 
                 // se tiver erro corrige a forma que está escrito a key "codigo" para "Codigo"(para ficar igual ao sistema nacional)
                 if (isset($return['erros'])) {
-                    if (count($return['erros']) > 0) {
+                    if (!empty($return['erros'])) {
                         foreach($return['erros'] as $key => $item) {
                             foreach($item as $keyR => $itemR) {
                                 if ($keyR === 'codigo') {

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -36,7 +36,7 @@ class Tools extends RestCurl
                 // retorno padrão do sistema nacional
                 $retornoR = $retorno['nfseXmlGZipB64'];
             }
-            $base_decode = base64_decode($retorno['nfseXmlGZipB64']);
+            $base_decode = base64_decode($retornoR);
             $gz_decode = gzdecode($base_decode);
             return $encoding ? mb_convert_encoding($gz_decode, 'ISO-8859-1') : $gz_decode;
         }

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -17,10 +17,25 @@ class Tools extends RestCurl
         $operacao = str_replace("{chave}", $chave, $this->getOperation('consultar_nfse'));
         $retorno = $this->getData($operacao);
 
-        if (isset($retorno['erro'])) {
+        if (
+            isset($retorno['erro']) ||
+            is_null($retorno) // culpa da pronim que retorna null quando a nota não é encontrada, ao invés de um erro
+        ) {
             return $retorno;
         }
         if ($retorno) {
+            $retornoR = null;
+            if (
+                isset($retorno['notas']) &&
+                isset($retorno['notas'][0]) &&
+                isset($retorno['notas'][0]['xmlGZipB64'])
+            ) {
+                // retorno padrão da pronim
+                $retornoR = $retorno['notas'][0]['xmlGZipB64'];
+            } else {
+                // retorno padrão do sistema nacional
+                $retornoR = $retorno['nfseXmlGZipB64'];
+            }
             $base_decode = base64_decode($retorno['nfseXmlGZipB64']);
             $gz_decode = gzdecode($base_decode);
             return $encoding ? mb_convert_encoding($gz_decode, 'ISO-8859-1') : $gz_decode;
@@ -49,7 +64,74 @@ class Tools extends RestCurl
         }
         $operacao = str_replace("{nSequencial}", $nSequencial, $operacao);
 
-        $retorno = $this->getData($operacao);
+        $retornoTemp = $this->getData($operacao);
+
+        /**
+         * não sei se isso é um erro de homologação ou se via acontecer tbm na produção
+         * mas durante os meus testes, notas que foram canceladas com o evento 101101 json
+         * já notas que foram canceladas por substituição, retornam uma array vazia
+         */
+        $retorno = null;
+        if (is_null($retornoTemp)) {
+            // até agora só a pronim retornou null quando não encontra a nota
+            $retorno = $retornoTemp;
+        } elseif(
+            !isset($retornoTemp['eventos']) &&
+            (   // identifica o retorno padrão da pronim
+                isset($retornoTemp[0]) &&
+                isset($retornoTemp[0]['xmlGZipB64'])
+            )
+        ) {
+            // como a rota de eventos da pronim devolve todos os eventos dentro dele
+            $tempArray = [];
+            foreach ($retornoTemp as $evento) {
+                if (
+                    is_null($tipoEvento) || // adiciona o evento se não for passado nenhum tipo de evento do parãmetro da função consultarNfseEventos()
+                    $tipoEvento == $evento['tipo'] // ou se o tipo de evento for passado for igual a um dos eventos recuperado
+                ) {
+                    $tempArray[] = [
+                        'chaveAcesso'                => $chave,
+                        'tipoEvento'                 => $evento['tipo'],
+                        'numeroPedidoRegistroEvento' => null, // o unico que não consegui recuperar
+                        'dataHoraRecebimento'        => $evento['dataInclusao'],
+                        'arquivoXml'                 => $evento['xmlGZipB64'],
+                    ];
+                }
+            }
+            // adiciona para que o retorno do evento fique o mais parecido com o do sistema nacional
+            // mas não consegue recuperar os campos, passarei eles como null
+            // "dataHoraProcessamento"
+            // "tipoAmbiente"
+            // "versaoAplicativo"
+            /**
+             * exemplo de requisição do sistema nacional
+             *
+             *   "dataHoraProcessamento" => "2026-02-05T16:42:08.0252693-03:00"
+             *   "tipoAmbiente" => 2
+             *   "versaoAplicativo" => "SefinNacional_1.6.0"
+             *   "eventos" => array:1 [
+             *       0 => array:5 [
+             *       "chaveAcesso" => "3106..."
+             *       "tipoEvento" => 105102
+             *       "numeroPedidoRegistroEvento" => 1
+             *       "dataHoraRecebimento" => "2026-02-02T17:32:31"
+             *       "arquivoXml" => "SDRzSUFBQUFBQUFFQUsxWTJaTHFTSE4rbFk2ZVMrSzB
+             */
+
+            $retorno = [
+                'dataHoraProcessamento' => null,
+                'tipoAmbiente' => null,
+                'versaoAplicativo' => null,
+            ];
+            // no sistema nacional quando não é encontrado nenhum evento a posição "eventos" não é passado
+            // farei o mesmo aqui
+            if (!empty($tempArray)) {
+                $retorno['eventos'] = $tempArray;
+            }
+        } else {
+            $retorno = $retornoTemp;
+        }
+
         return $retorno;
     }
 
@@ -99,9 +181,7 @@ class Tools extends RestCurl
         $content = '<?xml version="1.0" encoding="UTF-8"?>' . $content;
         $gz = gzencode($content);
         $data = base64_encode($gz);
-        $dados = [
-            'dpsXmlGZipB64' => $data
-        ];
+        $dados = $this->refactorFormatProvider($data, 1);
         $operacao = $this->getOperation('emitir_nfse');
         $retorno = $this->postData($operacao, json_encode($dados));
         return $retorno;
@@ -116,9 +196,7 @@ class Tools extends RestCurl
         $content = '<?xml version="1.0" encoding="UTF-8"?>' . $content;
         $gz = gzencode($content);
         $data = base64_encode($gz);
-        $dados = [
-            'pedidoRegistroEventoXmlGZipB64' => $data
-        ];
+        $dados = $this->refactorFormatProvider($data, 2);
         $operacao = str_replace("{chave}", $std->infPedReg->chNFSe, $this->getOperation('cancelar_nfse'));
         $retorno = $this->postData($operacao, json_encode($dados));
         return $retorno;

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -19,7 +19,7 @@ class Tools extends RestCurl
 
         if (
             isset($retorno['erro']) ||
-            is_null($retorno) // culpa da pronim que retorna null quando a nota não é encontrada, ao invés de um erro
+            is_null($retorno) // culpa da govCloud que retorna null quando a nota não é encontrada, ao invés de um erro
         ) {
             return $retorno;
         }
@@ -30,7 +30,7 @@ class Tools extends RestCurl
                 isset($retorno['notas'][0]) &&
                 isset($retorno['notas'][0]['xmlGZipB64'])
             ) {
-                // retorno padrão da pronim
+                // retorno padrão da govCloud
                 $retornoR = $retorno['notas'][0]['xmlGZipB64'];
             } else {
                 // retorno padrão do sistema nacional
@@ -73,16 +73,16 @@ class Tools extends RestCurl
          */
         $retorno = null;
         if (is_null($retornoTemp)) {
-            // até agora só a pronim retornou null quando não encontra a nota
+            // até agora só a govCloud retornou null quando não encontra a nota
             $retorno = $retornoTemp;
         } elseif(
             !isset($retornoTemp['eventos']) &&
-            (   // identifica o retorno padrão da pronim
+            (   // identifica o retorno padrão da govCloud
                 isset($retornoTemp[0]) &&
                 isset($retornoTemp[0]['xmlGZipB64'])
             )
         ) {
-            // como a rota de eventos da pronim devolve todos os eventos dentro dele
+            // como a rota de eventos da govCloud devolve todos os eventos dentro dele
             $tempArray = [];
             foreach ($retornoTemp as $evento) {
                 if (

--- a/storage/prefeituras.json
+++ b/storage/prefeituras.json
@@ -67,5 +67,5 @@
             "consultar_danfse_nfse_certificado": "NaoExisteEssaRota",
             "consultar_danfse_nfse_download": "NaoExisteEssaRota"
         }
-    },
+    }
 }

--- a/storage/prefeituras.json
+++ b/storage/prefeituras.json
@@ -31,5 +31,41 @@
             "cancelar_nfse" : "nfse/{chave}/eventos",
             "consultar_danfse": "nfse/{chave}"
         }
-    }
+    },
+    "3118601": {
+        "urls": {
+            "sefin_producao": "https://nfse-contagem.govbr.cloud/NFSe.Api",
+            "sefin_homologacao": "https://reformatributaria.govbr.cloud/NFSe.Api.Teste",
+            "adn_producao": "https://nfse-contagem.govbr.cloud/NFSe.Api",
+            "adn_homologacao": "https://reformatributaria.govbr.cloud/NFSe.Api.Teste"
+        },
+        "operations":{
+            "emitir_nfse" : "NotaNacional/EnviarSincrono",
+            "cancelar_nfse" : "NotaNacional/EnviarSincrono",
+            "consultar_danfse": "NaoExisteEssaRota",
+            "consultar_nfse": "NotaNacional/ConsultarNFSe/{chave}",
+            "consultar_eventos": "/NotaNacional/ConsultarEventos/{chave}",
+            "consultar_dps": "/NotaNacional/ConsultarDPS/{documento}/{serie}/{numero}",
+            "consultar_danfse_nfse_certificado": "NaoExisteEssaRota",
+            "consultar_danfse_nfse_download": "NaoExisteEssaRota"
+        }
+    },
+    "3542404": {
+        "urls": {
+            "sefin_producao": "https://regentefeijo.govbr.cloud/NFSe.Api",
+            "sefin_homologacao": "https://reformatributaria.govbr.cloud/NFSe.Api.Teste",
+            "adn_producao": "https://regentefeijo.govbr.cloud/NFSe.Api",
+            "adn_homologacao": "https://reformatributaria.govbr.cloud/NFSe.Api.Teste"
+        },
+        "operations":{
+            "emitir_nfse" : "NotaNacional/EnviarSincrono",
+            "cancelar_nfse" : "NotaNacional/EnviarSincrono",
+            "consultar_danfse": "NaoExisteEssaRota",
+            "consultar_nfse": "NotaNacional/ConsultarNFSe/{chave}",
+            "consultar_eventos": "/NotaNacional/ConsultarEventos/{chave}",
+            "consultar_dps": "/NotaNacional/ConsultarDPS/{documento}/{serie}/{numero}",
+            "consultar_danfse_nfse_certificado": "NaoExisteEssaRota",
+            "consultar_danfse_nfse_download": "NaoExisteEssaRota"
+        }
+    },
 }


### PR DESCRIPTION
**Descrição**
Este PR introduz o suporte aos municípios de Contagem (MG) e Regente Feijó (SP). Devido às particularidades do provedor nessas localidades, foram implementados ajustes na camada de comunicação para garantir a compatibilidade com o padrão do sistema nacional.

**Alterações Principais**
Suporte a Novos Municípios: Adição de Contagem-MG e Regente Feijó-SP.
Tratamento Diferenciado de Requisições: Implementação de lógica específica (via switch) para o preparo de envio e tratamento de resposta. Isso garante que, mesmo com as variações do provedor, a entrada e saída de dados do sistema permaneçam consistentes com o padrão nacional.
Refatoração de Arquitetura: Criação de uma estrutura (esqueleto) para facilitar a segregação do processamento de entrada e saída por município. O objetivo é permitir que futuras integrações com sistemas próprios de prefeituras sejam feitas de forma escalável e organizada.

**Detalhes Técnicos**
Homologação: O provedor em questão utiliza uma URL única de homologação que aponta para Regente Feijó, motivo pelo qual este município foi incluído simultaneamente a Contagem.

Limitações de Contagem (MG):
Não há rota disponível para recuperação da DANFSE.
Em casos de cancelamento por substituição, o sistema não disponibiliza o XML de evento para a nota cancelada.

Retrocompatibilidade: As alterações afetam exclusivamente os municípios listados no novo fluxo. Todos os demais municípios continuam operando normalmente sob o padrão nacional pré-existente.

Doc:. https://nfse-contagem.govbr.cloud/NFSe.Api/swagger/ui/index
Doc Hom:. https://reformatributaria.govbr.cloud/NFSe.Api.Teste/swagger/ui/index#/