### PR TITLE
Adicionado requisição SOAP

### DIFF
--- a/exemples/SoapConsultaNfse.php
+++ b/exemples/SoapConsultaNfse.php
@@ -1,0 +1,44 @@
+<?php
+
+// Este exemplo é para a consulta de um DPS utilizando SOAP, o XML modelo para esta consulta pode ser encontrado em storage/prefeituras/xml/consulta_dps_3147105.xml
+
+
+
+function makeNfseSoap (string $protocol): string
+{
+    // Carregar o XML modelo para a consulta de DPS
+    $xmlModelo = file_get_contents(storage_path("prefeituras/xml/consulta_dps_3147105.xml"));
+
+    // Criar uma instância do SOAP
+    $soap = new \Hadder\NfseNacional\Soap();
+
+    // Carregar o XML modelo para o SOAP
+    $soap->loadXml($xmlModelo);
+
+    // Devolver todas as tags editáveis do XML para que possam ser preenchidas
+    $tags = $soap->getEditableTags();
+
+    // Alterar os valores dos campos do XML com o que você deseja enviar para a prefeitura e devolver o XML pronto para ser enviado
+    return $soap->fill([
+        'ConsultarDps/CNPJ'         => '11.111.111/0001-11', // CNPJ do prestador
+        'ConsultarDps/IM'           => '12345678', // Inscrição Municipal do prestador
+        'ConsultarDps/Protocolo'    => $protocol, // Protocolo de emissão do DPS
+    ]);
+}
+
+function getNfseSoap (string $xml): array
+{
+    $config             = new stdClass();
+    $config->tpamb      = app()->environment('production') ? 1 : 2; //1 - Produção, 2 - Homologaçã
+    $config->prefeitura = '3147105';
+
+    $configJson = json_encode($config);
+    $content    = file_get_contents(storage_path("certificates/11111111000111/certificate.pfx"));
+    $password   = '11111111';
+    $cert       = \NFePHP\Common\Certificate::readPfx($content, $password);
+    $tools      = new \Hadder\NfseNacional\Tools($configJson, $cert);
+    return $tools->consultarDanfseWsdl($xml, 'ConsultarDps');
+}
+
+$xml        = makeNfseSoap('111111111111111');
+$response   = getNfseSoap($xml);

--- a/src/Soap.php
+++ b/src/Soap.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Hadder\NfseNacional;
+
+use DOMDocument;
+use DOMNode;
+use DOMXPath;
+use Exception;
+
+class Soap implements SoapInterface
+{
+    protected DOMDocument $dom;
+    protected DOMXPath $xpath;
+
+    /**
+     * Carrega XML modelo
+     */
+    public function loadXml(string $xmlString): void
+    {
+        $this->dom = new DOMDocument('1.0', 'UTF-8');
+        $this->dom->preserveWhiteSpace = false;
+        $this->dom->formatOutput = false;
+
+        if (!$this->dom->loadXML($xmlString)) {
+            throw new Exception("XML inválido.");
+        }
+
+        $this->xpath = new DOMXPath($this->dom);
+
+        $this->removeSignature();
+        $this->ensureRootId();
+    }
+
+    /**
+     * Remove qualquer Signature existente
+     */
+    protected function removeSignature(): void
+    {
+        $nodes = $this->xpath->query('//*[local-name()="Signature"]');
+
+        foreach ($nodes as $node) {
+            $node->parentNode->removeChild($node);
+        }
+    }
+
+    /**
+     * Garante que o elemento raiz tenha Id válido
+     */
+    protected function ensureRootId(): void
+    {
+        $root = $this->dom->documentElement;
+
+        if (!$root->hasAttribute('Id') || empty($root->getAttribute('Id'))) {
+            $root->setAttribute('Id', $this->generateId($root->localName));
+        }
+    }
+
+    /**
+     * Gerador padrão de Id seguro
+     */
+    protected function generateId(string $prefix): string
+    {
+        return $prefix . date('YmdHis') . rand(1000, 9999);
+    }
+
+    /**
+     * Retorna todas as tags editáveis (antes da Signature)
+     */
+    public function getEditableTags(): array
+    {
+        $editable = [];
+        $this->extractNodes($this->dom->documentElement, '', $editable);
+        return $editable;
+    }
+
+    protected function extractNodes(DOMNode $node, string $currentPath, array &$editable): void
+    {
+        if ($node->nodeType !== XML_ELEMENT_NODE) {
+            return;
+        }
+
+        if ($node->localName === 'Signature') {
+            return;
+        }
+
+        $newPath = $currentPath
+            ? $currentPath . '/' . $node->localName
+            : $node->localName;
+
+        if (
+            $node->childNodes->length === 1 &&
+            $node->firstChild->nodeType === XML_TEXT_NODE
+        ) {
+            $editable[] = $newPath;
+        }
+
+        foreach ($node->childNodes as $child) {
+            $this->extractNodes($child, $newPath, $editable);
+        }
+    }
+
+    /**
+     * Preenche XML dinamicamente
+     */
+    public function fill(array $data): string
+    {
+        foreach ($data as $path => $value) {
+            $nodes = $this->getNodesBySimplePath($path);
+
+            foreach ($nodes as $node) {
+                $node->nodeValue = $value;
+            }
+        }
+
+        return $this->dom->saveXML($this->dom->documentElement);
+    }
+
+    protected function getNodesBySimplePath(string $path): array
+    {
+        $segments = explode('/', $path);
+
+        $query = '/*[local-name()="' . array_shift($segments) . '"]';
+
+        foreach ($segments as $segment) {
+            $query .= '/*[local-name()="' . $segment . '"]';
+        }
+
+        $nodeList = $this->xpath->query($query);
+
+        $nodes = [];
+
+        foreach ($nodeList as $node) {
+            if ($node->localName !== 'Signature') {
+                $nodes[] = $node;
+            }
+        }
+
+        return $nodes;
+    }
+
+    public function render(): string
+    {
+        return $this->dom->saveXML($this->dom->documentElement);
+    }
+}

--- a/src/SoapInterface.php
+++ b/src/SoapInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Hadder\NfseNacional;
+
+interface SoapInterface
+{
+    /**
+     * Convert Soap::class data in XML
+     * @return string
+     */
+    public function render();
+}

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -69,6 +69,15 @@ class Tools extends RestCurl
         return null;
     }
 
+    public function consultarDanfseWsdl(string $content, string $tag)
+    {
+        $content = $this->sign($content, $tag, 'Id', $tag);
+        $content = '<?xml version="1.0" encoding="UTF-8"?>' . $content;
+        $operacao = $this->getOperation('consultar_danfse');
+        $retorno = $this->getSoap($operacao, $content);
+        return $retorno;
+    }
+
     /**
      * Consulta o DANFSe via NFSe caso o serviço direto falhe
      *
@@ -104,6 +113,15 @@ class Tools extends RestCurl
         ];
         $operacao = $this->getOperation('emitir_nfse');
         $retorno = $this->postData($operacao, json_encode($dados));
+        return $retorno;
+    }
+
+    public function enviaDpsWsdl($content)
+    {
+        $content = $this->sign($content, 'infDPS', '', 'DPS');
+        $content = '<?xml version="1.0" encoding="UTF-8"?>' . $content;
+        $operation = $this->getOperation('emitir_nfse');
+        $retorno = $this->postSoap($operation, $content);
         return $retorno;
     }
 

--- a/storage/prefeituras.json
+++ b/storage/prefeituras.json
@@ -31,5 +31,18 @@
             "cancelar_nfse" : "nfse/{chave}/eventos",
             "consultar_danfse": "nfse/{chave}"
         }
+    },
+    "3147105": {
+        "urls": {
+            "soap_producao": "https://parademinas.mg.issqn.quasar.srv.br/nfe/snissdigitalsvc",
+            "soap_homologacao": "https://parademinas.mg.des.issqn.quasar.tec.br/nfe/snissdigitalsvc",
+            "soap_wsdl_producao": "https://parademinas.mg.issqn.quasar.srv.br/nfe/snissdigitalsvc?wsdl",
+            "soap_wsdl_homologacao": "https://parademinas.mg.des.issqn.quasar.tec.br/nfe/snissdigitalsvc?wsdl"
+        },
+        "operations":{
+            "emitir_nfse" : "RecepcionarDps",
+            "cancelar_nfse" : "",
+            "consultar_danfse": "ConsultarDps"
+        }
     }
 }


### PR DESCRIPTION
Realizei a implementação de SOAP para prefeituras que utilizam as tags do emissor nacional para emissão da NFSe, porem não utilizam api rest para as comunicações 
 
 Implementação de Suporte a Consultas via SOAP (WSDL)
Esta alteração introduz a capacidade de comunicação com webservices baseados em SOAP para a emissão e consulta de DPS/NFSe, atendendo especificamente a prefeituras que ainda não operam exclusivamente via API REST Nacional ou que utilizam gateways específicos (como o Quasar).

 Alterações Realizadas
1. Core e Infraestrutura (RestCurl.php)
Novos Endpoints: Adicionada a estrutura para armazenar URLs de produção e homologação específicas para SOAP e seus respectivos WSDLs.

Métodos de Comunicação: Implementação dos métodos postSoap e getSoap utilizando a classe nativa \SoapClient do PHP, garantindo o tratamento de exceções via \SoapFault.

Resolução de URL: Atualização do método resolveUrl (Case 4) para alternar dinamicamente entre os endpoints SOAP baseados no ambiente (tpamb).

2. Manipulação de XML (Soap.php & SoapInterface.php)
Dinamismo no Preenchimento: Criação de uma nova classe Soap que permite carregar um XML modelo e preencher tags dinamicamente via XPath.

Sanitização: Implementação de lógica para remover assinaturas pré-existentes e garantir que o elemento raiz possua um Id válido antes da nova assinatura.

Interface: Contrato SoapInterface adicionado para padronizar a renderização dos dados.

3. Camada de Negócio e Integração (Tools.php)
Novas Operações: Adicionados os métodos consultarDanfseWsdl e enviaDpsWsdl.

Fluxo de Assinatura: Integração com o fluxo de assinatura digital existente antes do envio do envelope SOAP.

4. Configuração por Município (storage/prefeituras.json)
Prefeitura de Pará de Minas (3147105): Inclusão das configurações de URL e mapeamento de operações (RecepcionarDps, ConsultarDps) para o provedor local.