### PR TITLE
Correções de compatibilidade com PHP 8.5

### DIFF
--- a/src/Common/RestBase.php
+++ b/src/Common/RestBase.php
@@ -20,7 +20,7 @@ class RestBase
     protected $certfile;
     public $waitingTime = 45;
 
-    public function __construct(Certificate $certificate = null)
+    public function __construct(?Certificate $certificate = null)
     {
         $this->loadCertificate($certificate);
     }
@@ -30,7 +30,7 @@ class RestBase
      * @param Certificate $certificate
      * @return void
      */
-    public function loadCertificate(Certificate $certificate = null)
+    public function loadCertificate(?Certificate $certificate = null)
     {
         $this->isCertificateExpired($certificate);
         if (null !== $certificate) {
@@ -44,7 +44,7 @@ class RestBase
      * @return void
      * @throws Certificate\Exception\Expired
      */
-    private function isCertificateExpired(Certificate $certificate = null)
+    private function isCertificateExpired(?Certificate $certificate = null)
     {
         if (!$this->disableCertValidation) {
             if (null !== $certificate && $certificate->isExpired()) {

--- a/src/Dps.php
+++ b/src/Dps.php
@@ -43,7 +43,7 @@ class Dps implements DpsInterface
      * @param stdClass|null $std
      * @throws DOMException
      */
-    public function __construct(stdClass $std = null)
+    public function __construct(?stdClass $std = null)
     {
         $this->init($std);
         $this->dom = new Dom('1.0', 'UTF-8');
@@ -55,7 +55,7 @@ class Dps implements DpsInterface
      *
      * @param stdClass|null $dps
      */
-    private function init(stdClass $dps = null)
+    private function init(?stdClass $dps = null)
     {
         if (!empty($dps)) {
             $this->std = $this->propertiesToLower($dps);
@@ -68,7 +68,7 @@ class Dps implements DpsInterface
         }
     }
 
-    public function render(stdClass $std = null)
+    public function render(?stdClass $std = null)
     {
         if ($this->dom->hasChildNodes()) {
             $this->dom = new Dom('1.0', 'UTF-8');
@@ -1365,7 +1365,7 @@ class Dps implements DpsInterface
         return $this->dom->saveXML();
     }
 
-    public function renderEvento(stdClass $std = null)
+    public function renderEvento(?stdClass $std = null)
     {
         if ($this->dom->hasChildNodes()) {
             $this->dom = new Dom('1.0', 'UTF-8');

--- a/src/RestCurl.php
+++ b/src/RestCurl.php
@@ -229,7 +229,6 @@ class RestCurl extends RestBase
             }
             $headsize = curl_getinfo($oCurl, CURLINFO_HEADER_SIZE);
             $httpcode = curl_getinfo($oCurl, CURLINFO_HTTP_CODE);
-            curl_close($oCurl);
             $this->responseHead = trim(substr($response, 0, $headsize));
             $this->responseBody = trim(substr($response, $headsize));
             return json_decode($this->responseBody, true);


### PR DESCRIPTION
Isso resolve alguns warnings que temos atualmente:
- Implicitly marking parameter ... as nullable is deprecated, the explicit nullable type must be used instead
- função curl_close está descontinuada