### PR TITLE
Adiciona verificação antes de adicionar xMotivo no DOM

### DIFF
--- a/src/Dps.php
+++ b/src/Dps.php
@@ -162,12 +162,14 @@ class Dps implements DpsInterface
                 $this->std->infdps->subst->cmotivo,
                 true
             );
-            $this->dom->addChild(
-                $subst_inner,
-                'xMotivo',
-                $this->std->infdps->subst->xmotivo,
-                true
-            );
+            if (isset($this->std->infdps->subst->xmotivo)) {
+                $this->dom->addChild(
+                    $subst_inner,
+                    'xMotivo',
+                    $this->std->infdps->subst->xmotivo,
+                    true
+                );
+            }
         }
 
         if (isset($this->std->infdps->prest)) {


### PR DESCRIPTION
### Resumo da correção:
### Arquivo: src/Dps.php:165-172
Problema: O elemento xMotivo no bloco subst era sempre criado (addChild com 4º parâmetro true), mesmo quando a propriedade não era definida pelo usuário. Isso gerava:
1. Warning: Undefined property: stdClass::$xmotivo 
2. Elemento XML vazio <xMotivo/> que falhava validação (erro E1235)

- Raiz: propertiesToLower() converte todas as propriedades para minúsculo, então xMotivo vira xmotivo internamente. O código acessava xmotivo sem verificar se existe, e o true no addChild forçava a criação do elemento mesmo vazio.

- Correção: Envolveu o addChild do xMotivo em um if (isset(...)), seguindo o mesmo padrão usado no restante da biblioteca (ex: cMotivoEmisTI, chNFSeRej). Agora o elemento só é criado no XML quando o usuário fornece o valor, respeitando minOccurs="0" do XSD.